### PR TITLE
update rxdart dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.1.1] 7/6/2019
+* **BREAKING CHANGE** Updated rxdart dependency
+
 ## [0.1.0+1] 27/3/2019
 * No functional changes in this release. Changes were to fix formatting to meet Dart guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.1.1] 7/6/2019
+## [0.2.0] 10/6/2019
 * **BREAKING CHANGE** Updated rxdart dependency
 
 ## [0.1.0+1] 27/3/2019
@@ -14,7 +14,7 @@
 
 ## [0.0.4+2] - 15/8/2018
 
-* *BREAKING CHANGE* separated `onLoadMore` callback. There is now an `onLoadMore` that doesn't pass a boolean and is triggered when more items are being loaded and `onLoadMoreFinished` when more items have finished being loaded.
+* **BREAKING CHANGE** separated `onLoadMore` callback. There is now an `onLoadMore` that doesn't pass a boolean and is triggered when more items are being loaded and `onLoadMoreFinished` when more items have finished being loaded.
 * Updated README to explain `onLoadMore` and `onLoadMoreFinished`
 
 ## [0.0.4+1] - 15/8/2018
@@ -23,7 +23,7 @@
 
 ## [0.0.4] - 15/8/2018
 
-* *BREAKING CHANGES* fixed an issue that occurred where package no longer worked due to the way the list view was triggering the loading of more items. This was due to the fact that setState was being called while the build was occurred. Changed this now to use a `StreamBuilder` wrapped around a `ListView.builder` now so that upon reaching the nth item from the bottom will emit an item onto a stream that executes the function required to load more items and rebuild the `ListView` when the functions completes execution. As a result of these changes `itemCount` and `hasMore` are now callbacks
+* **BREAKING CHANGES** fixed an issue that occurred where package no longer worked due to the way the list view was triggering the loading of more items. This was due to the fact that setState was being called while the build was occurred. Changed this now to use a `StreamBuilder` wrapped around a `ListView.builder` now so that upon reaching the nth item from the bottom will emit an item onto a stream that executes the function required to load more items and rebuild the `ListView` when the functions completes execution. As a result of these changes `itemCount` and `hasMore` are now callbacks
 * Updated sample to add navigating to an item details page for testing
 
 ## [0.0.3] - 23/7/2018

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # incrementally_loading_listview
 
-An extension of the Flutter ListView widget for incrementally loading items upon scrolling. This could be used to load paginated data received from API requests
+An extension of the Flutter ListView widget for incrementally loading items upon scrolling. This could be used to load paginated data received from API requests. 
+
+*NOTE* this package depends on [rxdart](https://pub.dev/packages/rxdart). If you run into conflicts with different versions of rxdart, consider using dependency overrides as per this [link](https://flutter.dev/docs/development/packages-and-plugins/using-packages#conflict-resolution)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An extension of the Flutter ListView widget for incrementally loading items upon scrolling. This could be used to load paginated data received from API requests. 
 
-*NOTE* this package depends on [rxdart](https://pub.dev/packages/rxdart). If you run into conflicts with different versions of rxdart, consider using dependency overrides as per this [link](https://flutter.dev/docs/development/packages-and-plugins/using-packages#conflict-resolution)
+**NOTE**: this package depends on [rxdart](https://pub.dev/packages/rxdart). If you run into conflicts with different versions of rxdart, consider using dependency overrides as per this [link](https://flutter.dev/docs/development/packages-and-plugins/using-packages#conflict-resolution)
 
 ## Getting Started
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: incrementally_loading_listview
 description: An extension of the list view widget for incrementally loading data on scrolling
-version: 0.1.0+1
+version: 0.1.1
 author: Michael Bui <maikub84@gmail.com>
 homepage: https://github.com/MaikuB/incrementally_loading_listview
 
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.21.0
+  rxdart: ^0.22.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: incrementally_loading_listview
 description: An extension of the list view widget for incrementally loading data on scrolling
-version: 0.1.1
+version: 0.2.0
 author: Michael Bui <maikub84@gmail.com>
 homepage: https://github.com/MaikuB/incrementally_loading_listview
 


### PR DESCRIPTION
I was getting some version solving errors while using this library in my own project, noticed it was because rxdart was more out of date than another library I'm using. Thought I'd update it for you, tried to follow your structure for updates best I could. 

Nothing in the [rxdart changelog](https://pub.dev/packages/rxdart#-changelog-tab-) looks like it affects this project so it should be low to 0 risk.